### PR TITLE
[Feature] 소수점을 자르는 메서드, 테스트코드 작성

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A5E8D2DE2B57C52200F2E7BD /* ExchangeRateCalcAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2DD2B57C52200F2E7BD /* ExchangeRateCalcAppUITests.swift */; };
 		A5E8D2E02B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2DF2B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift */; };
 		A5E8D2EE2B57CB9A00F2E7BD /* DecimalPointWork.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2ED2B57CB9A00F2E7BD /* DecimalPointWork.swift */; };
+		A5E8D2F32B57CC0B00F2E7BD /* DecimalPointWorkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2F22B57CC0B00F2E7BD /* DecimalPointWorkTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		A5E8D2DD2B57C52200F2E7BD /* ExchangeRateCalcAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateCalcAppUITests.swift; sourceTree = "<group>"; };
 		A5E8D2DF2B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateCalcAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		A5E8D2ED2B57CB9A00F2E7BD /* DecimalPointWork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalPointWork.swift; sourceTree = "<group>"; };
+		A5E8D2F22B57CC0B00F2E7BD /* DecimalPointWorkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalPointWorkTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 		A5E8D2D22B57C52200F2E7BD /* ExchangeRateCalcAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				A5E8D2EF2B57CBD100F2E7BD /* CalculationWorkTests */,
 				A5E8D2D32B57C52200F2E7BD /* ExchangeRateCalcAppTests.swift */,
 			);
 			path = ExchangeRateCalcAppTests;
@@ -136,6 +139,14 @@
 				A5E8D2ED2B57CB9A00F2E7BD /* DecimalPointWork.swift */,
 			);
 			path = CalculationWork;
+			sourceTree = "<group>";
+		};
+		A5E8D2EF2B57CBD100F2E7BD /* CalculationWorkTests */ = {
+			isa = PBXGroup;
+			children = (
+				A5E8D2F22B57CC0B00F2E7BD /* DecimalPointWorkTests.swift */,
+			);
+			path = CalculationWorkTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -281,6 +292,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5E8D2D42B57C52200F2E7BD /* ExchangeRateCalcAppTests.swift in Sources */,
+				A5E8D2F32B57CC0B00F2E7BD /* DecimalPointWorkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A5E8D2D42B57C52200F2E7BD /* ExchangeRateCalcAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2D32B57C52200F2E7BD /* ExchangeRateCalcAppTests.swift */; };
 		A5E8D2DE2B57C52200F2E7BD /* ExchangeRateCalcAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2DD2B57C52200F2E7BD /* ExchangeRateCalcAppUITests.swift */; };
 		A5E8D2E02B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2DF2B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift */; };
+		A5E8D2EE2B57CB9A00F2E7BD /* DecimalPointWork.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2ED2B57CB9A00F2E7BD /* DecimalPointWork.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		A5E8D2D92B57C52200F2E7BD /* ExchangeRateCalcAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExchangeRateCalcAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2DD2B57C52200F2E7BD /* ExchangeRateCalcAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateCalcAppUITests.swift; sourceTree = "<group>"; };
 		A5E8D2DF2B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateCalcAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		A5E8D2ED2B57CB9A00F2E7BD /* DecimalPointWork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalPointWork.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +133,7 @@
 		A5E8D2EC2B57CABE00F2E7BD /* CalculationWork */ = {
 			isa = PBXGroup;
 			children = (
+				A5E8D2ED2B57CB9A00F2E7BD /* DecimalPointWork.swift */,
 			);
 			path = CalculationWork;
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5E8D2C12B57C51F00F2E7BD /* ViewController.swift in Sources */,
+				A5E8D2EE2B57CB9A00F2E7BD /* DecimalPointWork.swift in Sources */,
 				A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */,
 				A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */,
 			);

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		A5E8D2BB2B57C51F00F2E7BD /* ExchangeRateCalcApp */ = {
 			isa = PBXGroup;
 			children = (
+				A5E8D2EC2B57CABE00F2E7BD /* CalculationWork */,
 				A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */,
 				A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */,
 				A5E8D2C02B57C51F00F2E7BD /* ViewController.swift */,
@@ -125,6 +126,13 @@
 				A5E8D2DF2B57C52200F2E7BD /* ExchangeRateCalcAppUITestsLaunchTests.swift */,
 			);
 			path = ExchangeRateCalcAppUITests;
+			sourceTree = "<group>";
+		};
+		A5E8D2EC2B57CABE00F2E7BD /* CalculationWork */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CalculationWork;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/DecimalPointWork.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/DecimalPointWork.swift
@@ -6,3 +6,10 @@
 //
 
 import Foundation
+
+struct DecimalPointWork {
+    static func truncateDecimal(_ value: Double, point: Int) -> Double {
+        let multiplier = pow(10.0, Double(point))
+        return Double(Int(value * multiplier)) / multiplier
+    }
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/DecimalPointWork.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/DecimalPointWork.swift
@@ -1,0 +1,8 @@
+//
+//  DecimalPointWork.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/17/24.
+//
+
+import Foundation

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DecimalPointWorkTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DecimalPointWorkTests.swift
@@ -1,0 +1,35 @@
+//
+//  DecimalPointWorkTests.swift
+//  ExchangeRateCalcAppTests
+//
+//  Created by 류창휘 on 1/17/24.
+//
+
+import XCTest
+
+final class DecimalPointWorkTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DecimalPointWorkTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DecimalPointWorkTests.swift
@@ -6,30 +6,25 @@
 //
 
 import XCTest
+@testable import ExchangeRateCalcApp
 
 final class DecimalPointWorkTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func test_truncateDecimal_Double값이주어졌을때_두번째소수점에서자르는지확인() {
+        // Given
+        let value: Double = 123.123
+        let expectedValue = 123.12
+        // When
+        let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
+        // Then
+        XCTAssertEqual(returnValue, expectedValue)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func test_truncateDecimal_소주가없는값이주어졌을때_소수두번째값까지0이이나오는지확인() {
+        // Given
+        let value:Double = 123
+        let expectedValue = 123.00
+        // When
+        let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
+        // Then
+        XCTAssertEqual(returnValue, expectedValue)
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DecimalPointWorkTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DecimalPointWorkTests.swift
@@ -18,10 +18,19 @@ final class DecimalPointWorkTests: XCTestCase {
         // Then
         XCTAssertEqual(returnValue, expectedValue)
     }
-    func test_truncateDecimal_소주가없는값이주어졌을때_소수두번째값까지0이이나오는지확인() {
+    func test_truncateDecimal_소수가없는값이주어졌을때_소수두번째값까지0이이나오는지확인() {
         // Given
         let value:Double = 123
         let expectedValue = 123.00
+        // When
+        let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
+        // Then
+        XCTAssertEqual(returnValue, expectedValue)
+    }
+    func test_truncateDecimal_소수점첫번째자리까지값이주어졌을때_소수두번째값에0이이나오는지확인() {
+        // Given
+        let value:Double = 123.1
+        let expectedValue = 123.10
         // When
         let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
         // Then


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #1 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 소수점을 자르는 로직과 이를 테스트하는 로직을 작성했습니다. 

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
struct DecimalPointWork {
    static func truncateDecimal(_ value: Double, point: Int) -> Double {
        let multiplier = pow(10.0, Double(point))
        return Double(Int(value * multiplier)) / multiplier
    }
}
```
- 여러 곳에서 쓰일 수 있다고 판단해, static 타입 메서드로 처리해주었습니다.
- 추후에 소수점을 변경시킬 수 있다고 판단해 소수점을 수정할 수 있도록 만들었습니다. 

``` swift
func test_truncateDecimal_Double값이주어졌을때_두번째소수점에서자르는지확인() {
        // Given
        let value: Double = 123.123
        let expectedValue = 123.12
        // When
        let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
        // Then
        XCTAssertEqual(returnValue, expectedValue)
    }
    func test_truncateDecimal_소수가없는값이주어졌을때_소수두번째값까지0이이나오는지확인() {
        // Given
        let value:Double = 123
        let expectedValue = 123.00
        // When
        let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
        // Then
        XCTAssertEqual(returnValue, expectedValue)
    }
    func test_truncateDecimal_소수점첫번째자리까지값이주어졌을때_소수두번째값에0이이나오는지확인() {
        // Given
        let value:Double = 123.1
        let expectedValue = 123.10
        // When
        let returnValue = DecimalPointWork.truncateDecimal(value, point: 2)
        // Then
        XCTAssertEqual(returnValue, expectedValue)
    }
}
```
- 세가지 테스트
- 1) 소수점이 3자리를 넘어갈때 2자리에서 끊기
- 2) 소수점이 없을 때, .00으로 나오게 하기
- 3) 소수점이 1번째 자리까지 있을때, 두번째자리에 0나오게 하기 
