### PR TITLE
[Feature] : GetExchangeRateInformationUseCase 구현 및 테스트

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -90,6 +90,13 @@
 			path = Entity;
 			sourceTree = "<group>";
 		};
+		A59A9DD32B593E660035ADE5 /* Usecase */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Usecase;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -170,6 +177,7 @@
 		A5E8D2F92B591CD000F2E7BD /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DD32B593E660035ADE5 /* Usecase */,
 				A59A9DD02B592BD40035ADE5 /* Entity */,
 			);
 			path = Domain;

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -130,6 +130,13 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
+		A59A9DE82B594DC80035ADE5 /* UseCaseTests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = UseCaseTests;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -167,6 +174,7 @@
 		A5E8D2D22B57C52200F2E7BD /* ExchangeRateCalcAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DE82B594DC80035ADE5 /* UseCaseTests */,
 				A5E8D2EF2B57CBD100F2E7BD /* CalculationWorkTests */,
 			);
 			path = ExchangeRateCalcAppTests;

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */; };
 		A59A9DDB2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */; };
 		A59A9DE72B594D290035ADE5 /* ExchangeRateInformationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DE62B594D290035ADE5 /* ExchangeRateInformationConstants.swift */; };
+		A59A9DEA2B594EEB0035ADE5 /* GetExchangeRateInformationUsecaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DE92B594EEB0035ADE5 /* GetExchangeRateInformationUsecaseTests.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -48,6 +49,7 @@
 		A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTypes.swift; sourceTree = "<group>"; };
 		A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepositoryInterface.swift; sourceTree = "<group>"; };
 		A59A9DE62B594D290035ADE5 /* ExchangeRateInformationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationConstants.swift; sourceTree = "<group>"; };
+		A59A9DE92B594EEB0035ADE5 /* GetExchangeRateInformationUsecaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExchangeRateInformationUsecaseTests.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 		A59A9DE82B594DC80035ADE5 /* UseCaseTests */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DE92B594EEB0035ADE5 /* GetExchangeRateInformationUsecaseTests.swift */,
 			);
 			path = UseCaseTests;
 			sourceTree = "<group>";
@@ -440,6 +443,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5E8D2F32B57CC0B00F2E7BD /* NumberWorkTests.swift in Sources */,
+				A59A9DEA2B594EEB0035ADE5 /* GetExchangeRateInformationUsecaseTests.swift in Sources */,
 				A5E8D2F72B57E46400F2E7BD /* DateWorkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD12B592C030035ADE5 /* ExchangeRateInformationDTO.swift */; };
 		A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */; };
+		A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -42,6 +43,7 @@
 /* Begin PBXFileReference section */
 		A59A9DD12B592C030035ADE5 /* ExchangeRateInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationDTO.swift; sourceTree = "<group>"; };
 		A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExchangeRateInformationUsecase.swift; sourceTree = "<group>"; };
+		A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTypes.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 		A59A9DD62B593F4B0035ADE5 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 			files = (
 				A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */,
 				A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */,
+				A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */,
 				A5E8D2F52B57E42200F2E7BD /* DateWork.swift in Sources */,
 				A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */,
 				A5E8D2EE2B57CB9A00F2E7BD /* NumberWork.swift in Sources */,

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -120,6 +120,13 @@
 			path = RepositoryInterface;
 			sourceTree = "<group>";
 		};
+		A59A9DE52B594CF00035ADE5 /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -235,6 +242,7 @@
 		A5E8D2FD2B591E8400F2E7BD /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DE52B594CF00035ADE5 /* Constants */,
 				A5E8D2FE2B591EAA00F2E7BD /* Supports */,
 			);
 			path = Source;

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */; };
 		A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */; };
 		A59A9DDB2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */; };
+		A59A9DE72B594D290035ADE5 /* ExchangeRateInformationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DE62B594D290035ADE5 /* ExchangeRateInformationConstants.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -46,6 +47,7 @@
 		A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExchangeRateInformationUsecase.swift; sourceTree = "<group>"; };
 		A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTypes.swift; sourceTree = "<group>"; };
 		A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepositoryInterface.swift; sourceTree = "<group>"; };
+		A59A9DE62B594D290035ADE5 /* ExchangeRateInformationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationConstants.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 		A59A9DE52B594CF00035ADE5 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DE62B594D290035ADE5 /* ExchangeRateInformationConstants.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 				A5E8D2F52B57E42200F2E7BD /* DateWork.swift in Sources */,
 				A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */,
 				A5E8D2EE2B57CB9A00F2E7BD /* NumberWork.swift in Sources */,
+				A59A9DE72B594D290035ADE5 /* ExchangeRateInformationConstants.swift in Sources */,
 				A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */,
 				A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */,
 			);

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD12B592C030035ADE5 /* ExchangeRateInformationDTO.swift */; };
+		A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -40,6 +41,7 @@
 
 /* Begin PBXFileReference section */
 		A59A9DD12B592C030035ADE5 /* ExchangeRateInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationDTO.swift; sourceTree = "<group>"; };
+		A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExchangeRateInformationUsecase.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 		A59A9DD32B593E660035ADE5 /* Usecase */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */,
 			);
 			path = Usecase;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */,
+				A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */,
 				A5E8D2F52B57E42200F2E7BD /* DateWork.swift in Sources */,
 				A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */,
 				A5E8D2EE2B57CB9A00F2E7BD /* NumberWork.swift in Sources */,

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -100,6 +100,13 @@
 			path = Usecase;
 			sourceTree = "<group>";
 		};
+		A59A9DD62B593F4B0035ADE5 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -196,6 +203,7 @@
 		A5E8D2FB2B591CFA00F2E7BD /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DD62B593F4B0035ADE5 /* Base */,
 			);
 			path = Network;
 			sourceTree = "<group>";

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD12B592C030035ADE5 /* ExchangeRateInformationDTO.swift */; };
 		A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */; };
 		A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */; };
+		A59A9DDB2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -44,6 +45,7 @@
 		A59A9DD12B592C030035ADE5 /* ExchangeRateInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationDTO.swift; sourceTree = "<group>"; };
 		A59A9DD42B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExchangeRateInformationUsecase.swift; sourceTree = "<group>"; };
 		A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTypes.swift; sourceTree = "<group>"; };
+		A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepositoryInterface.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -108,6 +110,14 @@
 				A59A9DD72B593F8A0035ADE5 /* ErrorTypes.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		A59A9DD92B59408D0035ADE5 /* RepositoryInterface */ = {
+			isa = PBXGroup;
+			children = (
+				A59A9DDA2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift */,
+			);
+			path = RepositoryInterface;
 			sourceTree = "<group>";
 		};
 		A5E8D2B02B57C51F00F2E7BD = {
@@ -190,6 +200,7 @@
 		A5E8D2F92B591CD000F2E7BD /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9DD92B59408D0035ADE5 /* RepositoryInterface */,
 				A59A9DD32B593E660035ADE5 /* Usecase */,
 				A59A9DD02B592BD40035ADE5 /* Entity */,
 			);
@@ -392,6 +403,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A59A9DDB2B5940E00035ADE5 /* ExchangeRateinformationRepositoryInterface.swift in Sources */,
 				A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */,
 				A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */,
 				A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */,

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/RepositoryInterface/ExchangeRateinformationRepositoryInterface.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/RepositoryInterface/ExchangeRateinformationRepositoryInterface.swift
@@ -1,0 +1,8 @@
+//
+//  ExchangeRateinformationRepositoryInterface.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/18/24.
+//
+
+import Foundation

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/RepositoryInterface/ExchangeRateinformationRepositoryInterface.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/RepositoryInterface/ExchangeRateinformationRepositoryInterface.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+import Combine
+
+protocol ExchangeRateinformationRepositoryInterface {
+    func data() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes>
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/Usecase/GetExchangeRateInformationUsecase.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/Usecase/GetExchangeRateInformationUsecase.swift
@@ -6,3 +6,18 @@
 //
 
 import Foundation
+import Combine
+
+protocol GetExchangeRateInformationUsecaseProcotol {
+    func execute() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes>
+}
+
+struct GetExchangeRateInformationUsecase: GetExchangeRateInformationUsecaseProcotol {
+    private let exchangeRateInformationRepository: ExchangeRateinformationRepositoryInterface
+    init(exchangeRateInformationRepository: ExchangeRateinformationRepositoryInterface) {
+        self.exchangeRateInformationRepository = exchangeRateInformationRepository
+    }
+    func execute() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes> {
+        return self.exchangeRateInformationRepository.data()
+    }
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/Usecase/GetExchangeRateInformationUsecase.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/Usecase/GetExchangeRateInformationUsecase.swift
@@ -1,0 +1,8 @@
+//
+//  GetExchangeRateInformationUsecase.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/18/24.
+//
+
+import Foundation

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Network/Base/ErrorTypes.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Network/Base/ErrorTypes.swift
@@ -1,0 +1,8 @@
+//
+//  ErrorTypes.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/18/24.
+//
+
+import Foundation

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Network/Base/ErrorTypes.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Network/Base/ErrorTypes.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+enum ErrorTypes: Error {
+    case decoingError
+    case invalidURL
+    case noData
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Source/Constants/ExchangeRateInformationConstants.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Source/Constants/ExchangeRateInformationConstants.swift
@@ -1,0 +1,12 @@
+//
+//  ExchangeRateInformationConstants.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/18/24.
+//
+
+import Foundation
+
+struct ExchangeRateInformationConstants {
+    static let dummyData = ExchangeRateInformationDTO(succes: true, terms: "https://currencylayer.com/terms", privacy: "https://currencylayer.com/privacy", timestamp: 1705572303, source: "USD", quotes: Quotes(koreaExChangeRate: 320.489701, japenExChangeRate: 147.811026, philippinesChangeRate: 55.828506))
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/UseCaseTests/GetExchangeRateInformationUsecaseTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/UseCaseTests/GetExchangeRateInformationUsecaseTests.swift
@@ -6,30 +6,83 @@
 //
 
 import XCTest
+import Combine
+@testable import ExchangeRateCalcApp
 
-final class GetExchangeRateInformationUsecaseTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+struct MockExchangeRateinformationRepository: ExchangeRateinformationRepositoryInterface {
+    let hasError: Bool
+    init(hasError: Bool) {
+        self.hasError = hasError
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func data() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes> {
+        if hasError {
+            return Fail(error: ErrorTypes.noData)
+                .eraseToAnyPublisher()
+        } else {
+            let exchangeRateData = ExchangeRateInformationConstants.dummyData
+            return Just(exchangeRateData)
+                .setFailureType(to: ErrorTypes.self)
+                .eraseToAnyPublisher()
         }
     }
+}
 
+final class GetExchangeRateInformationUsecaseTests: XCTestCase {
+    var sut: GetExchangeRateInformationUsecase!
+    var cancellables: Set<AnyCancellable>!
+    override func setUpWithError() throws {
+        cancellables = []
+    }
+    override func tearDownWithError() throws {
+        sut = nil
+        cancellables = nil
+    }
+    func test_usecase_데이터가주어졌을때_데이터가출력되는지확인() {
+        // Given
+        sut = GetExchangeRateInformationUsecase(exchangeRateInformationRepository: MockExchangeRateinformationRepository(hasError: false))
+        let expectedValue = ExchangeRateInformationConstants.dummyData
+        let expectation = self.expectation(description: "데이터 조회 성공")
+        // When
+        var returnValue: ExchangeRateInformationDTO?
+        sut.execute()
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    return
+                case .failure(let error):
+                    XCTFail("테스트 실패 \(error)")
+                }
+            } receiveValue: { data in
+                returnValue = data
+                expectation.fulfill()
+            }.store(in: &cancellables)
+        // Then
+        self.wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(returnValue?.quotes.japenExChangeRate, expectedValue.quotes.japenExChangeRate)
+        XCTAssertEqual(returnValue?.quotes.koreaExChangeRate, expectedValue.quotes.koreaExChangeRate)
+        XCTAssertEqual(returnValue?.quotes.philippinesChangeRate, expectedValue.quotes.philippinesChangeRate)
+    }
+    func test_usecase_에러상황이주어졌을때_에러를출력되는지확인() {
+        // Given
+        sut = GetExchangeRateInformationUsecase(exchangeRateInformationRepository: MockExchangeRateinformationRepository(hasError: true))
+        let expectationValue: ErrorTypes = .noData
+        let expectation = self.expectation(description: "noData 에러 발생")
+        // When
+        var returnValue: ErrorTypes?
+        sut.execute()
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    return
+                case .failure(let error):
+                    returnValue = error
+                    expectation.fulfill()
+                }
+            } receiveValue: { data in
+                XCTFail("테스트 실패 \(data)")
+            }.store(in: &cancellables)
+        // Then
+        self.wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(returnValue, expectationValue)
+    }
 }

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/UseCaseTests/GetExchangeRateInformationUsecaseTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/UseCaseTests/GetExchangeRateInformationUsecaseTests.swift
@@ -1,0 +1,35 @@
+//
+//  GetExchangeRateInformationUsecaseTests.swift
+//  ExchangeRateCalcAppTests
+//
+//  Created by 류창휘 on 1/18/24.
+//
+
+import XCTest
+
+final class GetExchangeRateInformationUsecaseTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #11 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- GetExchangeRateInformationUseCase 생성
- GetExchangeRateInformationUseCase 테스트 코드 작성
- ExchangeRateinformationRepositoryInterface 생성
- MockExchangeRateinformationRepository 생성

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
struct MockExchangeRateinformationRepository: ExchangeRateinformationRepositoryInterface {
    let hasError: Bool
    init(hasError: Bool) {
        self.hasError = hasError
    }
    func data() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes> {
        if hasError {
            return Fail(error: ErrorTypes.noData)
                .eraseToAnyPublisher()
        } else {
            let exchangeRateData = ExchangeRateInformationConstants.dummyData
            return Just(exchangeRateData)
                .setFailureType(to: ErrorTypes.self)
                .eraseToAnyPublisher()
        }
    }
}
```
- hasError 조건을 통해 데이터와 에러 경우를 테스트 하고자 했습니다.

