### PR TITLE
[Feature] ExchangeRateinformationRepository 구현 및 테스트

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A59A9E0C2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E0B2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift */; };
 		A59A9E0E2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E0D2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift */; };
 		A59A9E112B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */; };
+		A59A9E142B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -64,6 +65,7 @@
 		A59A9E0B2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationSession.swift; sourceTree = "<group>"; };
 		A59A9E0D2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationGetServiceTests.swift; sourceTree = "<group>"; };
 		A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepository.swift; sourceTree = "<group>"; };
+		A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepositoryTests.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -202,6 +204,14 @@
 			path = Repository;
 			sourceTree = "<group>";
 		};
+		A59A9E122B5BBC040035ADE5 /* RepositoryTests */ = {
+			isa = PBXGroup;
+			children = (
+				A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */,
+			);
+			path = RepositoryTests;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -240,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				A59A9DF82B5A60160035ADE5 /* NetworkTests */,
+				A59A9E122B5BBC040035ADE5 /* RepositoryTests */,
 				A59A9DE82B594DC80035ADE5 /* UseCaseTests */,
 				A5E8D2EF2B57CBD100F2E7BD /* CalculationWorkTests */,
 			);
@@ -518,6 +529,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A59A9E0E2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift in Sources */,
+				A59A9E142B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift in Sources */,
 				A5E8D2F32B57CC0B00F2E7BD /* NumberWorkTests.swift in Sources */,
 				A59A9DEA2B594EEB0035ADE5 /* GetExchangeRateInformationUsecaseTests.swift in Sources */,
 				A5E8D2F72B57E46400F2E7BD /* DateWorkTests.swift in Sources */,

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A59A9E082B5B91CB0035ADE5 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E072B5B91CB0035ADE5 /* Requestable.swift */; };
 		A59A9E0C2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E0B2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift */; };
 		A59A9E0E2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E0D2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift */; };
+		A59A9E112B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -62,6 +63,7 @@
 		A59A9E072B5B91CB0035ADE5 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		A59A9E0B2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationSession.swift; sourceTree = "<group>"; };
 		A59A9E0D2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationGetServiceTests.swift; sourceTree = "<group>"; };
+		A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepository.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 		A59A9E0F2B5BB8260035ADE5 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -497,6 +500,7 @@
 				A59A9DF52B5A4F740035ADE5 /* Secrets.swift in Sources */,
 				A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */,
 				A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */,
+				A59A9E112B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift in Sources */,
 				A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */,
 				A5E8D2F52B57E42200F2E7BD /* DateWork.swift in Sources */,
 				A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */,

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -192,6 +192,13 @@
 			path = Session;
 			sourceTree = "<group>";
 		};
+		A59A9E0F2B5BB8260035ADE5 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -284,6 +291,7 @@
 		A5E8D2FA2B591CD600F2E7BD /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9E0F2B5BB8260035ADE5 /* Repository */,
 			);
 			path = Data;
 			sourceTree = "<group>";

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Data/Repository/ExchangeRateinformationRepository.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Data/Repository/ExchangeRateinformationRepository.swift
@@ -6,3 +6,14 @@
 //
 
 import Foundation
+import Combine
+
+struct ExchangeRateinformationRepository: ExchangeRateinformationRepositoryInterface {
+    private let service: GetService
+    init(service: GetService) {
+        self.service = service
+    }
+    func data() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes> {
+        self.service.request(from: "\(Secrets.baseURL)live?access_key=\(Secrets.apiKey)")
+    }
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Data/Repository/ExchangeRateinformationRepository.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Data/Repository/ExchangeRateinformationRepository.swift
@@ -1,0 +1,8 @@
+//
+//  ExchangeRateinformationRepository.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/20/24.
+//
+
+import Foundation

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/RepositoryTests/ExchangeRateinformationRepositoryTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/RepositoryTests/ExchangeRateinformationRepositoryTests.swift
@@ -1,0 +1,52 @@
+//
+//  ExchangeRateinformationRepositoryTests.swift
+//  ExchangeRateCalcAppTests
+//
+//  Created by 류창휘 on 1/20/24.
+//
+
+import XCTest
+import Combine
+@testable import ExchangeRateCalcApp
+
+final class ExchangeRateinformationRepositoryTests: XCTestCase {
+    var sut: ExchangeRateinformationRepository!
+    var cancellables: Set<AnyCancellable>!
+    override func setUpWithError() throws {
+        sut = ExchangeRateinformationRepository(service: GetService(session: MockSession()))
+        cancellables = []
+    }
+    override func tearDownWithError() throws {
+        sut = nil
+        cancellables = nil
+    }
+    func test_ExchangeRateinformationRepository_data메서드호출했을때_데이터넘어오는지확인() {
+        // Given
+        let expectedValue = ExchangeRateInformationConstants.dummyData
+        let expectation = self.expectation(description: "데이터 조회 성공")
+        // When
+        var returnValue: ExchangeRateInformationDTO?
+        sut.data()
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    return
+                case .failure(let error):
+                    XCTFail("테스트 실패 \(error)")
+                }
+            } receiveValue: { (data: ExchangeRateInformationDTO) in
+                returnValue = data
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        // Then
+        self.wait(for: [expectation], timeout: 10)
+        XCTAssertEqual(returnValue?.privacy, expectedValue.privacy)
+        XCTAssertEqual(returnValue?.source, expectedValue.source)
+        XCTAssertEqual(returnValue?.success, expectedValue.success)
+        XCTAssertEqual(returnValue?.timestamp, expectedValue.timestamp)
+        XCTAssertEqual(returnValue?.quotes.japenExChangeRate, expectedValue.quotes.japenExChangeRate)
+        XCTAssertEqual(returnValue?.quotes.koreaExChangeRate, expectedValue.quotes.koreaExChangeRate)
+        XCTAssertEqual(returnValue?.quotes.philippinesChangeRate, expectedValue.quotes.philippinesChangeRate)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #21 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- ExchangeRateinformationRepository 구현
- ExchangeRateinformationRepository 테스트 코드 작성

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
struct ExchangeRateinformationRepository: ExchangeRateinformationRepositoryInterface {
    private let service: GetService
    init(service: GetService) {
        self.service = service
    }
    func data() -> AnyPublisher<ExchangeRateInformationDTO, ErrorTypes> {
        self.service.request(from: "\(Secrets.baseURL)live?access_key=\(Secrets.apiKey)")
    }
}
```
- Interface를 채택해 Repository를 구현했습니다. 
``` swift
func test_ExchangeRateinformationRepository_data메서드호출했을때_데이터넘어오는지확인() {
        // Given
        let expectedValue = ExchangeRateInformationConstants.dummyData
        let expectation = self.expectation(description: "데이터 조회 성공")
        // When
        var returnValue: ExchangeRateInformationDTO?
        sut.data()
            .sink { completion in
                switch completion {
                case .finished:
                    return
                case .failure(let error):
                    XCTFail("테스트 실패 \(error)")
                }
            } receiveValue: { (data: ExchangeRateInformationDTO) in
                returnValue = data
                expectation.fulfill()
            }
            .store(in: &cancellables)
        // Then
        self.wait(for: [expectation], timeout: 10)
        XCTAssertEqual(returnValue?.privacy, expectedValue.privacy)
        XCTAssertEqual(returnValue?.source, expectedValue.source)
        XCTAssertEqual(returnValue?.success, expectedValue.success)
        XCTAssertEqual(returnValue?.timestamp, expectedValue.timestamp)
        XCTAssertEqual(returnValue?.quotes.japenExChangeRate, expectedValue.quotes.japenExChangeRate)
        XCTAssertEqual(returnValue?.quotes.koreaExChangeRate, expectedValue.quotes.koreaExChangeRate)
        XCTAssertEqual(returnValue?.quotes.philippinesChangeRate, expectedValue.quotes.philippinesChangeRate)
    }
```
- Repository에 대해 테스트코드를 작성했습니다. 
