### PR TITLE
[Feature] : MainViewModel 구현 및 연결

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A59A9E112B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */; };
 		A59A9E142B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */; };
 		A59A9E162B5BC3D60035ADE5 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E152B5BC3D60035ADE5 /* MainViewModel.swift */; };
+		A59A9E192B5BD0820035ADE5 /* MainItemViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E182B5BD0820035ADE5 /* MainItemViewData.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -68,6 +69,7 @@
 		A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepository.swift; sourceTree = "<group>"; };
 		A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepositoryTests.swift; sourceTree = "<group>"; };
 		A59A9E152B5BC3D60035ADE5 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		A59A9E182B5BD0820035ADE5 /* MainItemViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainItemViewData.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -214,6 +216,14 @@
 			path = RepositoryTests;
 			sourceTree = "<group>";
 		};
+		A59A9E172B5BD06B0035ADE5 /* ItemViewData */ = {
+			isa = PBXGroup;
+			children = (
+				A59A9E182B5BD0820035ADE5 /* MainItemViewData.swift */,
+			);
+			path = ItemViewData;
+			sourceTree = "<group>";
+		};
 		A5E8D2B02B57C51F00F2E7BD = {
 			isa = PBXGroup;
 			children = (
@@ -356,6 +366,7 @@
 		A5E8D2FF2B591EEB00F2E7BD /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9E172B5BD06B0035ADE5 /* ItemViewData */,
 				A5E8D3002B591EFA00F2E7BD /* ViewController */,
 				A5E8D3012B591F0B00F2E7BD /* ViewModel */,
 			);
@@ -514,6 +525,7 @@
 				A59A9DF52B5A4F740035ADE5 /* Secrets.swift in Sources */,
 				A59A9DD22B592C030035ADE5 /* ExchangeRateInformationDTO.swift in Sources */,
 				A59A9DD52B593EA50035ADE5 /* GetExchangeRateInformationUsecase.swift in Sources */,
+				A59A9E192B5BD0820035ADE5 /* MainItemViewData.swift in Sources */,
 				A59A9E112B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift in Sources */,
 				A59A9DD82B593F8A0035ADE5 /* ErrorTypes.swift in Sources */,
 				A5E8D2F52B57E42200F2E7BD /* DateWork.swift in Sources */,

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A59A9E0E2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E0D2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift */; };
 		A59A9E112B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */; };
 		A59A9E142B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */; };
+		A59A9E162B5BC3D60035ADE5 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59A9E152B5BC3D60035ADE5 /* MainViewModel.swift */; };
 		A5E8D2BD2B57C51F00F2E7BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */; };
 		A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */; };
 		A5E8D2C12B57C51F00F2E7BD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8D2C02B57C51F00F2E7BD /* MainViewController.swift */; };
@@ -66,6 +67,7 @@
 		A59A9E0D2B5BA49A0035ADE5 /* ExchangeRateInformationGetServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateInformationGetServiceTests.swift; sourceTree = "<group>"; };
 		A59A9E102B5BB8540035ADE5 /* ExchangeRateinformationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepository.swift; sourceTree = "<group>"; };
 		A59A9E132B5BBC1A0035ADE5 /* ExchangeRateinformationRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateinformationRepositoryTests.swift; sourceTree = "<group>"; };
+		A59A9E152B5BC3D60035ADE5 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		A5E8D2B92B57C51F00F2E7BD /* ExchangeRateCalcApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExchangeRateCalcApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E8D2BC2B57C51F00F2E7BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5E8D2BE2B57C51F00F2E7BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 		A5E8D3012B591F0B00F2E7BD /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				A59A9E152B5BC3D60035ADE5 /* MainViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -521,6 +524,7 @@
 				A5E8D2BF2B57C51F00F2E7BD /* SceneDelegate.swift in Sources */,
 				A59A9DED2B5A403F0035ADE5 /* GetService.swift in Sources */,
 				A59A9E0C2B5BA3300035ADE5 /* ExchangeRateInformationSession.swift in Sources */,
+				A59A9E162B5BC3D60035ADE5 /* MainViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ItemViewData/MainItemViewData.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ItemViewData/MainItemViewData.swift
@@ -1,0 +1,27 @@
+//
+//  MainItemViewData.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/20/24.
+//
+
+import Foundation
+
+struct MainItemViewData {
+    let viewTime: String
+    let exchangeRate: String
+    let result: String
+    let krwRate: Double
+    let jpyRate: Double
+    let phpRate: Double
+    let exchangeRateInformationData: ExchangeRateInformationDTO
+    init(exchangeRateInformationData: ExchangeRateInformationDTO) {
+        self.exchangeRateInformationData = exchangeRateInformationData
+        self.viewTime = "\(exchangeRateInformationData.timestamp ?? 0)"
+        self.result = "수취금액은 0 KRW 입니다"
+        self.exchangeRate = "\(NumberWork.addComma(NumberWork.truncateDecimal(exchangeRateInformationData.quotes.koreaExChangeRate ?? 0, point: 2))) KRW / USD"
+        self.krwRate = exchangeRateInformationData.quotes.koreaExChangeRate ?? 0
+        self.jpyRate = exchangeRateInformationData.quotes.japenExChangeRate ?? 0
+        self.phpRate = exchangeRateInformationData.quotes.philippinesChangeRate ?? 0
+    }
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewController/MainViewController.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewController/MainViewController.swift
@@ -11,8 +11,7 @@ import Combine
 class MainViewController: UIViewController {
     // MARK: - Property
     private let viewModel = MainViewModel(getExchangeRateInformationUsecase: GetExchangeRateInformationUsecase(exchangeRateInformationRepository: ExchangeRateinformationRepository(service: GetService.shared)))
-    private var  cancellables: Set<AnyCancellable> = []
-    private let nationArray = ["한국(KRW)", "일본(JPY)", "필리핀(PHP)"]
+    private var cancellables: Set<AnyCancellable> = []
     // MARK: - UI Property
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -139,6 +138,7 @@ class MainViewController: UIViewController {
         setLayout()
         setConfig()
         setDelegate()
+        actions()
         viewModel.getData()
         viewModel.combineData()
         setBinding()
@@ -175,13 +175,14 @@ class MainViewController: UIViewController {
                 self.exchangeRateTitleLabel.text = data
             }
             .store(in: &cancellables)
+    }
+    // MARK: - Action Helper
+    private func actions() {
         self.transferTitleAmountTextField.addTarget(self, action: #selector(self.textFieldDidChange), for: .editingChanged)
     }
+    // MARK: - @objc Methods
     @objc func textFieldDidChange() {
         viewModel.inputTransferAmount(amount: transferTitleAmountTextField.text ?? "")
-    }
-    private func setBind(data: ExchangeRateInformationDTO) {
-        print(data, "????????")
     }
 }
 // MARK: - Extensions
@@ -190,10 +191,12 @@ extension MainViewController: UIPickerViewDelegate, UIPickerViewDataSource {
         return 1
     }
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return nationArray.count
+        return CountryCase.allCases.count
     }
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return nationArray[row]
+        let countryCases = CountryCase.allCases
+        let selectedCountry = countryCases[row]
+        return selectedCountry.getCountryTitle()
     }
     func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
         return 70
@@ -216,7 +219,6 @@ extension MainViewController: UITextFieldDelegate {
         addToolBar()
     }
 }
-
 extension MainViewController {
     // MARK: - Custom Method
     private func addToolBar() {

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
@@ -8,11 +8,10 @@
 import Foundation
 import Combine
 
-enum CountryCase: String {
+enum CountryCase: String, CaseIterable {
     case korea = "USDKRW"
     case japen = "USDJPY"
     case philippines = "USDPHP"
-    
     func getCountryTitle() -> String {
         switch self {
         case .korea:
@@ -36,7 +35,7 @@ final class MainViewModel: ObservableObject {
     @Published var transferTitleAmount: String = ""
     @Published var outputAmount: String = "수취금액은 0 KRW 입니다"
     @Published var exchnageRate: String = ""
-    
+    // MARK: - In ViewController
     func getData() {
         getExchangeRateInformationUsecase.execute()
             .sink { completion in
@@ -54,9 +53,8 @@ final class MainViewModel: ObservableObject {
     }
     func combineData() {
         Publishers.CombineLatest($countryCase, $transferTitleAmount)
-            .sink { [weak self]country, amount in
+            .sink { [weak self] country, amount in
                 guard let self = self else { return }
-                print(country, amount, "????")
                 self.calcResultAmount(country: country, amount: amount)
             }
             .store(in: &cancellables)
@@ -67,6 +65,7 @@ final class MainViewModel: ObservableObject {
     func inputTransferAmount(amount: String) {
         transferTitleAmount = amount
     }
+    // MARK: - In ViewModel
     private func calcResultAmount(country: CountryCase, amount: String) {
         switch country {
         case .korea:

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
@@ -6,3 +6,108 @@
 //
 
 import Foundation
+import Combine
+
+enum CountryCase: String {
+    case korea = "USDKRW"
+    case japen = "USDJPY"
+    case philippines = "USDPHP"
+    
+    func getCountryTitle() -> String {
+        switch self {
+        case .korea:
+            return "한국 (KRW)"
+        case .japen:
+            return "일본 (JPY)"
+        case .philippines:
+            return "필리핀 (PHP)"
+        }
+    }
+}
+final class MainViewModel: ObservableObject {
+    private var cancellables: Set<AnyCancellable> = []
+    private let getExchangeRateInformationUsecase: GetExchangeRateInformationUsecaseProcotol
+    init(getExchangeRateInformationUsecase: GetExchangeRateInformationUsecaseProcotol) {
+        self.getExchangeRateInformationUsecase = getExchangeRateInformationUsecase
+    }
+    @Published var exchangeRateInformationData: MainItemViewData?
+    @Published var countryCase: CountryCase = .korea
+    @Published var receptionCountry: String = CountryCase.korea.getCountryTitle()
+    @Published var transferTitleAmount: String = ""
+    @Published var outputAmount: String = "수취금액은 0 KRW 입니다"
+    @Published var exchnageRate: String = ""
+    
+    func getData() {
+        getExchangeRateInformationUsecase.execute()
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    return
+                case .failure(_):
+                    return
+                }
+            } receiveValue: { [weak self] data in
+                guard let self = self else { return }
+                self.exchangeRateInformationData = MainItemViewData(exchangeRateInformationData: data)
+            }
+            .store(in: &cancellables)
+    }
+    func combineData() {
+        Publishers.CombineLatest($countryCase, $transferTitleAmount)
+            .sink { [weak self]country, amount in
+                guard let self = self else { return }
+                print(country, amount, "????")
+                self.calcResultAmount(country: country, amount: amount)
+            }
+            .store(in: &cancellables)
+    }
+    func changeCountry(country: CountryCase) {
+        countryCase = country
+    }
+    func inputTransferAmount(amount: String) {
+        transferTitleAmount = amount
+    }
+    private func calcResultAmount(country: CountryCase, amount: String) {
+        switch country {
+        case .korea:
+            receptionCountry = getReceptionCountry(country: .korea)
+            outputAmount = getResultAmount(exchangeRate: exchangeRateInformationData?.krwRate ?? 0, country: .korea, amount: amount)
+            exchnageRate = getExchangeRate(exchangeRate: exchangeRateInformationData?.krwRate ?? 0, country: .korea)
+        case .japen:
+            receptionCountry = getReceptionCountry(country: .japen)
+            outputAmount = getResultAmount(exchangeRate: exchangeRateInformationData?.jpyRate ?? 0, country: .japen, amount: amount)
+            exchnageRate = getExchangeRate(exchangeRate: exchangeRateInformationData?.jpyRate ?? 0, country: .japen)
+        case .philippines:
+            receptionCountry = getReceptionCountry(country: .philippines)
+            outputAmount = getResultAmount(exchangeRate: exchangeRateInformationData?.jpyRate ?? 0, country: .philippines, amount: amount)
+            exchnageRate = getExchangeRate(exchangeRate: exchangeRateInformationData?.phpRate ?? 0, country: .philippines)
+        }
+    }
+    private func getReceptionCountry(country: CountryCase) -> String {
+        return country.getCountryTitle()
+    }
+    private func getResultAmount(exchangeRate: Double, country: CountryCase, amount: String) -> String {
+        guard let doubleAmount = Double(amount) else { return "" }
+        switch country {
+        case .korea:
+            return "수취금액은 \(numberWorks(amount: exchangeRate * doubleAmount)) KRW 입니다."
+        case .japen:
+            return "수취금액은 \(numberWorks(amount: exchangeRate * doubleAmount)) JPY 입니다."
+        case .philippines:
+            return "수취금액은 \(numberWorks(amount: exchangeRate * doubleAmount)) PHP 입니다."
+        }
+    }
+    private func getExchangeRate(exchangeRate: Double, country: CountryCase) -> String {
+        switch country {
+        case .korea:
+            return "\(numberWorks(amount: exchangeRate)) KRW / USD"
+        case .japen:
+            return "\(numberWorks(amount: exchangeRate)) JPY / USD"
+        case .philippines:
+            return "\(numberWorks(amount: exchangeRate)) PHP / USD"
+        }
+    }
+    private func numberWorks(amount: Double) -> String {
+        return NumberWork.addComma(NumberWork.truncateDecimal(amount, point: 2))
+    }
+}

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  MainViewModel.swift
+//  ExchangeRateCalcApp
+//
+//  Created by 류창휘 on 1/20/24.
+//
+
+import Foundation


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #23 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- ViewModel 구현
- MainViewController 데이터 바인딩 작업

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
    @Published var exchangeRateInformationData: MainItemViewData?
    @Published var countryCase: CountryCase = .korea
    @Published var receptionCountry: String = CountryCase.korea.getCountryTitle()
    @Published var transferTitleAmount: String = ""
    @Published var outputAmount: String = "수취금액은 0 KRW 입니다"
    @Published var exchnageRate: String = ""
```
- Published 프로퍼티 래퍼를 통해 상태값을 갖고 있도록 구현했습니다. 
