### PR TITLE
[Feature] : timestampToString 구현 및 테스트

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/DateWork.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/DateWork.swift
@@ -32,4 +32,23 @@ struct DateWork {
             return returnValue
         }
     }
+    static func timestampToString(timeStamp: TimeInterval, types: DateConvertTypes) -> String {
+        let date = Date(timeIntervalSince1970: timeStamp)
+        let dateFormatter = DateFormatter()
+        var returnValue = ""
+        switch types {
+        case .yyyyMMddHHmm:
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+            returnValue = dateFormatter.string(from: date)
+            return returnValue
+        case .yyyyMMdd:
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            returnValue = dateFormatter.string(from: date)
+            return returnValue
+        case .MMdd:
+            dateFormatter.dateFormat = "MM-dd"
+            returnValue = dateFormatter.string(from: date)
+            return returnValue
+        }
+    }
 }

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/Entity/ExchangeRateInformationDTO.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Domain/Entity/ExchangeRateInformationDTO.swift
@@ -11,7 +11,7 @@ struct ExchangeRateInformationDTO: Decodable {
     let success: Bool?
     let terms: String?
     let privacy: String?
-    let timestamp: Int?
+    let timestamp: Double?
     let source: String?
     let quotes: Quotes
 }

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Source/Constants/ExchangeRateInformationConstants.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Source/Constants/ExchangeRateInformationConstants.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct ExchangeRateInformationConstants {
-    static let dummyData = ExchangeRateInformationDTO(success: true, terms: "https://currencylayer.com/terms", privacy: "https://currencylayer.com/privacy", timestamp: 1705660383, source: "USD", quotes: Quotes(koreaExChangeRate: 1333.794975, japenExChangeRate: 147.988972, philippinesChangeRate: 56.029499))
+    static let dummyData = ExchangeRateInformationDTO(success: true, terms: "https://currencylayer.com/terms", privacy: "https://currencylayer.com/privacy", timestamp: 1705847342, source: "USD", quotes: Quotes(koreaExChangeRate: 1333.794975, japenExChangeRate: 147.988972, philippinesChangeRate: 56.029499))
     static let jsonString = """
 {
     "success": true,
     "terms": "https://currencylayer.com/terms",
     "privacy": "https://currencylayer.com/privacy",
-    "timestamp": 1705660383,
+    "timestamp": 1705847342,
     "source": "USD",
     "quotes": {
         "USDAED": 3.672899,

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DateWorkTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/DateWorkTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import ExchangeRateCalcApp
 
 final class DateWorkTests: XCTestCase {
-    func test_데이트값이들어왔을때_yyyyMMddHHmm형식으로반환되는지확인() {
+    func test_convertToString_데이트값이들어왔을때_yyyyMMddHHmm형식으로반환되는지확인() {
         // Given
         let expectedValue = "2022-01-17 15:30"
         let dateFormatter = DateFormatter()
@@ -20,7 +20,7 @@ final class DateWorkTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedValue, returnValue)
     }
-    func test_데이트값이들어왔을때_yyyyMMdd형식으로반환되는지확인() {
+    func test_convertToString_데이트값이들어왔을때_yyyyMMdd형식으로반환되는지확인() {
         // Given
         let expectedValue = "2022-01-17"
         let dateFormatter = DateFormatter()
@@ -31,7 +31,7 @@ final class DateWorkTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedValue, returnValue)
     }
-    func test_데이트값이들어왔을때_MMdd형식으로반환되는지확인() {
+    func test_convertToString_데이트값이들어왔을때_MMdd형식으로반환되는지확인() {
         // Given
         let expectedValue = "01-17"
         let dateFormatter = DateFormatter()
@@ -39,6 +39,33 @@ final class DateWorkTests: XCTestCase {
         let value = dateFormatter.date(from: expectedValue)!
         // When
         let returnValue = DateWork.convertToString(value, types: .MMdd)
+        // Then
+        XCTAssertEqual(expectedValue, returnValue)
+    }
+    func test_timestampToString_데이트값이들어왔을때_yyyyMMddHHmm형식으로반환되는지확인() {
+        // Given
+        let value: Double = ExchangeRateInformationConstants.dummyData.timestamp!
+        let expectedValue = "2024-01-21 23:29"
+        // When
+        let returnValue = DateWork.timestampToString(timeStamp: value, types: .yyyyMMddHHmm)
+        // Then
+        XCTAssertEqual(expectedValue, returnValue)
+    }
+    func test_timestampToString_데이트값이들어왔을때_yyyyMMdd형식으로반환되는지확인() {
+        // Given
+        let value: Double = ExchangeRateInformationConstants.dummyData.timestamp!
+        let expectedValue = "2024-01-21"
+        // When
+        let returnValue = DateWork.timestampToString(timeStamp: value, types: .yyyyMMdd)
+        // Then
+        XCTAssertEqual(expectedValue, returnValue)
+    }
+    func test_timestampToString_데이트값이들어왔을때_MMdd형식으로반환되는지확인() {
+        // Given
+        let value: Double = ExchangeRateInformationConstants.dummyData.timestamp!
+        let expectedValue = "01-21"
+        // When
+        let returnValue = DateWork.timestampToString(timeStamp: value, types: .MMdd)
         // Then
         XCTAssertEqual(expectedValue, returnValue)
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #25 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- timestamp를 날짜로 바꾸는 메서드를 작성했습니다.
- 해당 메서드를 테스트했습니다. 
- 테스트를 위해 Conatants 데이터를 수정했습니다. 

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
func test_timestampToString_데이트값이들어왔을때_yyyyMMddHHmm형식으로반환되는지확인() {
        // Given
        let value: Double = ExchangeRateInformationConstants.dummyData.timestamp!
        let expectedValue = "2024-01-21 23:29"
        // When
        let returnValue = DateWork.timestampToString(timeStamp: value, types: .yyyyMMddHHmm)
        // Then
        XCTAssertEqual(expectedValue, returnValue)
    }
    func test_timestampToString_데이트값이들어왔을때_yyyyMMdd형식으로반환되는지확인() {
        // Given
        let value: Double = ExchangeRateInformationConstants.dummyData.timestamp!
        let expectedValue = "2024-01-21"
        // When
        let returnValue = DateWork.timestampToString(timeStamp: value, types: .yyyyMMdd)
        // Then
        XCTAssertEqual(expectedValue, returnValue)
    }
    func test_timestampToString_데이트값이들어왔을때_MMdd형식으로반환되는지확인() {
        // Given
        let value: Double = ExchangeRateInformationConstants.dummyData.timestamp!
        let expectedValue = "01-21"
        // When
        let returnValue = DateWork.timestampToString(timeStamp: value, types: .MMdd)
        // Then
        XCTAssertEqual(expectedValue, returnValue)
    }
```
- 3가지 경우 (년월일날짜, 년월일, 월일)를 테스트했습니다. 