### PR TITLE
[Feature] : checkReceptionAmountState 메서드 구현 및 테스트

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/NumberWork.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/CalculationWork/NumberWork.swift
@@ -6,7 +6,10 @@
 //
 
 import Foundation
-
+/*
+ 콤마기능 참고
+ https://velog.io/@juh2/Swift-%EC%88%AB%EC%9E%90%EC%97%90-%EC%BD%A4%EB%A7%88-%EB%84%A3%EA%B8%B0-%EB%B9%BC%EA%B8%B0-%EA%B0%80%EA%B2%A9-%ED%91%9C%EC%8B%9C
+ */
 struct NumberWork {
     static func truncateDecimal(_ value: Double, point: Int) -> Double {
         let multiplier = pow(10.0, Double(point))
@@ -17,8 +20,11 @@ struct NumberWork {
         numberFormatter.numberStyle = .decimal
         return numberFormatter.string(from: NSNumber(value: value)) ?? ""
     }
-    /*
-     콤마기능 참고
-     https://velog.io/@juh2/Swift-%EC%88%AB%EC%9E%90%EC%97%90-%EC%BD%A4%EB%A7%88-%EB%84%A3%EA%B8%B0-%EB%B9%BC%EA%B8%B0-%EA%B0%80%EA%B2%A9-%ED%91%9C%EC%8B%9C
-     */
+    static func checkReceptionAmountState(amount: Double) -> Bool {
+        var returnValue: Bool = true
+        if amount < 0 || amount > 10000 {
+            returnValue = false
+        }
+        return returnValue
+    }
 }

--- a/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/NumberWorkTests.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcAppTests/CalculationWorkTests/NumberWorkTests.swift
@@ -56,4 +56,34 @@ final class NumberWorkTests: XCTestCase {
         // Then
         XCTAssertEqual(returnValue, expectedValue)
     }
+    func test_checkReceptionAmountState_0보다작을때_false가반환되는지확인() {
+        // Given
+        let value: Double = -1.0
+        // When
+        let returnValue = NumberWork.checkReceptionAmountState(amount: value)
+        // Then
+        XCTAssertFalse(returnValue)
+    }
+    func test_checkReceptionAmountState_0이상10000이하일때_true가반환되는지확인() {
+        // Given
+        let value: Double = 500
+        let secondValue: Double = 10000
+        let thirdValue: Double = 0
+        // When
+        let returnValue = NumberWork.checkReceptionAmountState(amount: value)
+        let secondReturnValue = NumberWork.checkReceptionAmountState(amount: secondValue)
+        let thirdReturnValue = NumberWork.checkReceptionAmountState(amount: thirdValue)
+        // Then
+        XCTAssertTrue(returnValue)
+        XCTAssertTrue(secondReturnValue)
+        XCTAssertTrue(thirdReturnValue)
+    }
+    func test_checkReceptionAmountState_10000보다클때_false가반환되는지확인() {
+        // Given
+        let value: Double = 10000.1
+        // When
+        let returnValue = NumberWork.checkReceptionAmountState(amount: value)
+        // Then
+        XCTAssertFalse(returnValue)
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #30 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- alert이 생성되는 경우 (0보다 작거나 10000보다 클때)의 조건을 메소드로 만들었습니다.
- 해당 메서드를 테스트했습니다. 

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
func test_checkReceptionAmountState_0보다작을때_false가반환되는지확인() {
        // Given
        let value: Double = -1.0
        // When
        let returnValue = NumberWork.checkReceptionAmountState(amount: value)
        // Then
        XCTAssertFalse(returnValue)
    }
    func test_checkReceptionAmountState_0이상10000이하일때_true가반환되는지확인() {
        // Given
        let value: Double = 500
        let secondValue: Double = 10000
        let thirdValue: Double = 0
        // When
        let returnValue = NumberWork.checkReceptionAmountState(amount: value)
        let secondReturnValue = NumberWork.checkReceptionAmountState(amount: secondValue)
        let thirdReturnValue = NumberWork.checkReceptionAmountState(amount: thirdValue)
        // Then
        XCTAssertTrue(returnValue)
        XCTAssertTrue(secondReturnValue)
        XCTAssertTrue(thirdReturnValue)
    }
    func test_checkReceptionAmountState_10000보다클때_false가반환되는지확인() {
        // Given
        let value: Double = 10000.1
        // When
        let returnValue = NumberWork.checkReceptionAmountState(amount: value)
        // Then
        XCTAssertFalse(returnValue)
    }
```
