### PR TITLE
[Feature] : 수취금액에 따라 alert 생성되는 기능 구현

### DIFF
--- a/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/xcshareddata/xcschemes/ExchangeRateCalcApp.xcscheme
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp.xcodeproj/xcshareddata/xcschemes/ExchangeRateCalcApp.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5E8D2B82B57C51F00F2E7BD"
+               BuildableName = "ExchangeRateCalcApp.app"
+               BlueprintName = "ExchangeRateCalcApp"
+               ReferencedContainer = "container:ExchangeRateCalcApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5E8D2CE2B57C52200F2E7BD"
+               BuildableName = "ExchangeRateCalcAppTests.xctest"
+               BlueprintName = "ExchangeRateCalcAppTests"
+               ReferencedContainer = "container:ExchangeRateCalcApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5E8D2D82B57C52200F2E7BD"
+               BuildableName = "ExchangeRateCalcAppUITests.xctest"
+               BlueprintName = "ExchangeRateCalcAppUITests"
+               ReferencedContainer = "container:ExchangeRateCalcApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5E8D2B82B57C51F00F2E7BD"
+            BuildableName = "ExchangeRateCalcApp.app"
+            BlueprintName = "ExchangeRateCalcApp"
+            ReferencedContainer = "container:ExchangeRateCalcApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5E8D2B82B57C51F00F2E7BD"
+            BuildableName = "ExchangeRateCalcApp.app"
+            BlueprintName = "ExchangeRateCalcApp"
+            ReferencedContainer = "container:ExchangeRateCalcApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewController/MainViewController.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewController/MainViewController.swift
@@ -10,7 +10,7 @@ import Combine
 
 class MainViewController: UIViewController {
     // MARK: - Property
-    private let viewModel = MainViewModel(getExchangeRateInformationUsecase: GetExchangeRateInformationUsecase(exchangeRateInformationRepository: ExchangeRateinformationRepository(service: GetService.shared)))
+    private let viewModel = MainViewModel(getExchangeRateInformationUsecase: GetExchangeRateInformationUsecase(exchangeRateInformationRepository: ExchangeRateinformationRepository(service: GetService(session: MockSession()))))
     private var cancellables: Set<AnyCancellable> = []
     // MARK: - UI Property
     private let titleLabel: UILabel = {
@@ -175,6 +175,15 @@ class MainViewController: UIViewController {
                 self.exchangeRateTitleLabel.text = data
             }
             .store(in: &cancellables)
+        viewModel.$receptionAmountState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] data in
+                guard let self = self else { return }
+                if data == false {
+                    showAlert()
+                }
+            }
+            .store(in: &cancellables)
     }
     // MARK: - Action Helper
     private func actions() {
@@ -183,6 +192,7 @@ class MainViewController: UIViewController {
     private func showAlert() {
         let alert = UIAlertController(title: "알림", message: "송금액이 바르지 않습니다.", preferredStyle: .alert)
         self.present(alert, animated: true)
+        self.resetTextField()
         Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
             alert.dismiss(animated: true)
         }
@@ -228,6 +238,9 @@ extension MainViewController: UITextFieldDelegate {
 }
 extension MainViewController {
     // MARK: - Custom Method
+    private func resetTextField() {
+        transferTitleAmountTextField.text = ""
+    }
     private func addToolBar() {
         let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 44))
         toolBar.sizeToFit()

--- a/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/ExchangeRateCalcApp/ExchangeRateCalcApp/Presentation/Main/ViewModel/MainViewModel.swift
@@ -35,6 +35,7 @@ final class MainViewModel: ObservableObject {
     @Published var transferTitleAmount: String = ""
     @Published var outputAmount: String = "수취금액은 0 KRW 입니다"
     @Published var exchnageRate: String = ""
+    @Published var receptionAmountState: Bool = true
     // MARK: - In ViewController
     func getData() {
         getExchangeRateInformationUsecase.execute()
@@ -55,7 +56,12 @@ final class MainViewModel: ObservableObject {
         Publishers.CombineLatest($countryCase, $transferTitleAmount)
             .sink { [weak self] country, amount in
                 guard let self = self else { return }
-                self.calcResultAmount(country: country, amount: amount)
+                if showAlertState(amount: Double(amount) ?? 0) {
+                    receptionStateToFalse()
+                    resetOutputAmount()
+                } else {
+                    self.calcResultAmount(country: country, amount: amount)
+                }
             }
             .store(in: &cancellables)
     }
@@ -81,6 +87,15 @@ final class MainViewModel: ObservableObject {
             outputAmount = getResultAmount(exchangeRate: exchangeRateInformationData?.jpyRate ?? 0, country: .philippines, amount: amount)
             exchnageRate = getExchangeRate(exchangeRate: exchangeRateInformationData?.phpRate ?? 0, country: .philippines)
         }
+    }
+    private func resetOutputAmount() {
+        outputAmount = ""
+    }
+    private func receptionStateToFalse() {
+        receptionAmountState = false
+    }
+    private func showAlertState(amount: Double) -> Bool {
+        return !NumberWork.checkReceptionAmountState(amount: amount)
     }
     private func getReceptionCountry(country: CountryCase) -> String {
         return country.getCountryTitle()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #33 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- MockSession으로 테스트 환경 변경했습니다. 
- 수취금액을 받을 수 있는 환경을 만들었습니다. 
## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
``` swift
    private let viewModel = MainViewModel(getExchangeRateInformationUsecase: GetExchangeRateInformationUsecase(exchangeRateInformationRepository: ExchangeRateinformationRepository(service: GetService(session: MockSession()))))
```
- api call 횟수를 줄이기 위해 MockSession으로 변경했습니다. 
``` swift
   @Published var receptionAmountState: Bool = true
```
- 다음 프로퍼티래퍼 프로퍼티 변수를 활용해 상태관리를 했습니다. 